### PR TITLE
Feature/accurate respond to

### DIFF
--- a/lib/choices/rails.rb
+++ b/lib/choices/rails.rb
@@ -28,7 +28,10 @@ module Choices::Rails
   end
 
   def respond_to?(method, include_private = false)
-    super(method) or method.to_s =~ /=$/ or (method.to_s =~ /\?$/ and @choices.key?($`))
+    super(method) or
+      method.to_s =~ /=$/ or
+      (method.to_s =~ /\?$/ and @choices.key?($`)) or
+      @choices.key?(method)
   end
 
   def[](key)


### PR DESCRIPTION
#### :tophat: What? Why?

Review it after the [previous one](https://github.com/teambox/choices/pull/2)

This pr adds accurate `respond_to?`, before that was missing this check `@choices.key?(method)`
#### :ghost: GIF

![](http://media0.giphy.com/media/hvdcplILldiG4/giphy.gif)
